### PR TITLE
Fix lftp return 1 when trying to chmod

### DIFF
--- a/conda-recipes/pygdf-feedstock/ci_support/ftp_upload.sh
+++ b/conda-recipes/pygdf-feedstock/ci_support/ftp_upload.sh
@@ -12,6 +12,6 @@ lftp -f "
 set dns:order "inet"
 open ftp://$FTP_HOST
 user $FTP_USER $FTP_PASSWORD
-mirror -R --continue --reverse --no-empty-dirs -i \.tar.bz2$ $LOCALPATH $REMOTEPATH
+mirror -R --continue --reverse --no-empty-dirs --no-perms -i \.tar.bz2$ $LOCALPATH $REMOTEPATH
 bye
 "


### PR DESCRIPTION
The lftp mirror option try to (unnecessarily) chmod the files, but sometimes this command can cause a silent error.

Please contact me if there are any problems.