### PR TITLE
Sentencepiece x86 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,24 @@ env:
     # The BINSTAR Token for uploading to anaconda.org/powerai
     - secure: "JZRf0nvjA0bNtlHCo2FiF9Xls11cYLoEK4JComWELDq0Qi1wOtlORR9t9RgyOCeldUt0n8ZiDtGVh42jCyI9xqo+lMpzZsp4GWu3apMSiDfFRNhDrakYxU1FMefathMHBCTk8rmq+P1LX7i/V+wPbNyzoSoNzcci3FmEc6eRUEGM/sBgHqH/xyvRFGZnSXbOMTigzgVSruZOVtL6opxHfo1RnxlU/dR5lytKIKm00r+GPK1w9tuwOPTdGpZUaWA6/aoxMQkUNnKqrZq382xBJ6TFgzmkkY80wJFnvchg0NuPqI7oNoA8z30W0vgYbZ7nno3SExjoCYbwCLWPlwIwsCEipEUG1lFPvVwAMELkCWu22JX95e34ZKxd5SR143/509CFMKHK5UrvLqg4tI7EgjrRpLcEI8utvNdjTCp/KUOcXbLq+cw1TMnzDwFuIdgPfsKGrTNreuaiHxCdt2NKuy8oD497WcMOUpq4rWoWXjDXeUfwxOt6GEH1F07Em5Ng0mSiwyCHxiL5XERpYj4lAnSnMBIaIXaHOWlGpron0jAtcpTu3lIY2rF7zdpUFSGNVnaiwwHUD7RDxy96zc/ig0X7DVIofeNTTML/rYsHEbB+hO92sBll+lxEq1xjeAO8Khsp0ohJLOyM3iglBgHxXrSfLhcYk6pmKrOqi1onJK0="
 
-
 matrix:
   include:
-    - env: CONFIG=linux_noarch UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux-ppc64le
-      arch: ppc64le
+      language: generic
+
+    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux-ppc64le
+      language: generic
+
+    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
+      os: linux-64
+      language: generic
+
+    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
+      os: linux-64
       language: generic
 
 script:
-  -  cd conda-recipes/tensorflow-datasets-feedstock
-  -  "travis_wait 60 sleep 3600 &"
+  -  cd conda-recipes/sentencepiece-feedstock
   -  ./ci_support/run_docker_build.sh

--- a/conda-recipes/sentencepiece-feedstock/.ci_support/linux_python3.6.yaml
+++ b/conda-recipes/sentencepiece-feedstock/.ci_support/linux_python3.6.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/conda-recipes/sentencepiece-feedstock/.ci_support/linux_python3.7.yaml
+++ b/conda-recipes/sentencepiece-feedstock/.ci_support/linux_python3.7.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/conda-recipes/sentencepiece-feedstock/ci_support/build_steps.sh
+++ b/conda-recipes/sentencepiece-feedstock/ci_support/build_steps.sh
@@ -28,8 +28,6 @@ conda-build:
 
 CONDARC
 
-/usr/bin/sudo -n yum install -y gcc-c++
-
 conda config --prepend channels https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
 export IBM_POWERAI_LICENSE_ACCEPT=yes
 

--- a/conda-recipes/sentencepiece-feedstock/ci_support/run_docker_build.sh
+++ b/conda-recipes/sentencepiece-feedstock/ci_support/run_docker_build.sh
@@ -39,6 +39,11 @@ rm -f "$DONE_CANARY"
 # Enable running in interactive mode attached to a tty
 DOCKER_RUN_ARGS=" -it "
 
+if [ -z "${DOCKER_IMAGE}" ]; then
+  echo "WARNING: DOCKER_IMAGE variable not set. Falling back to condaforge/linux-anvil-ppc64le"
+  DOCKER_IMAGE="condaforge/linux-anvil-ppc64le"
+fi
+
 docker run ${DOCKER_RUN_ARGS} \
                         -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
                         -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
@@ -48,7 +53,7 @@ docker run ${DOCKER_RUN_ARGS} \
                         -e UPLOAD_PACKAGES \
                         -e CI \
                         -a stdin -a stdout -a stderr \
-                        condaforge/linux-anvil-ppc64le \
+                        $DOCKER_IMAGE \
                         bash \
                         /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
 

--- a/conda-recipes/sentencepiece-feedstock/recipe/0001-Use-CXX11_ABI-to-build-TensorFlow.patch
+++ b/conda-recipes/sentencepiece-feedstock/recipe/0001-Use-CXX11_ABI-to-build-TensorFlow.patch
@@ -1,0 +1,27 @@
+From 09b18ea93687a125e46b7d9dc7f1ebfaf01ff2d9 Mon Sep 17 00:00:00 2001
+From: "William D. Irons" <wdirons@us.ibm.com>
+Date: Mon, 18 Nov 2019 20:26:44 +0000
+Subject: [PATCH] Use CXX11_ABI to build TensorFlow
+
+As TensorFlow in WML-CE is built with the CXX11_ABI
+---
+ src/CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a2356d4..0e4cd10 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -211,9 +211,6 @@ if (NOT MSVC)
+   else()
+     set(CMAKE_CXX_FLAGS "-O3 -Wall -fPIC ${CMAKE_CXX_FLAGS}")
+   endif()
+-  if (SPM_ENABLE_TENSORFLOW_SHARED)
+-    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+-  endif()
+   if (SPM_NO_THREADLOCAL)
+     add_definitions(-DSPM_NO_THREADLOCAL=1)
+     add_definitions(-DGOOGLE_PROTOBUF_NO_THREADLOCAL=1)
+-- 
+2.23.0
+

--- a/conda-recipes/sentencepiece-feedstock/recipe/build.sh
+++ b/conda-recipes/sentencepiece-feedstock/recipe/build.sh
@@ -17,6 +17,12 @@
 
 set -ex
 
+ARCH=`uname -p`
+if [[ "${ARCH}" == 'ppc64le' ]]; then
+    ARCH_SO_NAME="powerpc64le"
+else
+    ARCH_SO_NAME=${ARCH}
+fi
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} .. -DSPM_BUILD_TEST=ON -DSPM_ENABLE_TENSORFLOW_SHARED=ON
@@ -30,7 +36,7 @@ python setup.py install
 
 SYS_PYTHON_MAJOR=$(python -c "import sys;print(sys.version_info.major)")
 SYS_PYTHON_MINOR=$(python -c "import sys;print(sys.version_info.minor)")
-patchelf --set-rpath $LD_LIBRARY_PATH $PREFIX/lib/python${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}/site-packages/sentencepiece-$PKG_VERSION-py${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}-linux-ppc64le.egg/_sentencepiece.cpython-${CONDA_PY}m-powerpc64le-linux-gnu.so
+patchelf --set-rpath $LD_LIBRARY_PATH $PREFIX/lib/python${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}/site-packages/sentencepiece-$PKG_VERSION-py${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}-linux-${ARCH}.egg/_sentencepiece.cpython-${CONDA_PY}m-${ARCH_SO_NAME}-linux-gnu.so
 
 cd ../tensorflow
 python setup.py install

--- a/conda-recipes/sentencepiece-feedstock/recipe/build.sh
+++ b/conda-recipes/sentencepiece-feedstock/recipe/build.sh
@@ -23,6 +23,9 @@ if [[ "${ARCH}" == 'ppc64le' ]]; then
 else
     ARCH_SO_NAME=${ARCH}
 fi
+
+PAGE_SIZE=`getconf PAGE_SIZE`
+
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} .. -DSPM_BUILD_TEST=ON -DSPM_ENABLE_TENSORFLOW_SHARED=ON
@@ -36,7 +39,7 @@ python setup.py install
 
 SYS_PYTHON_MAJOR=$(python -c "import sys;print(sys.version_info.major)")
 SYS_PYTHON_MINOR=$(python -c "import sys;print(sys.version_info.minor)")
-patchelf --set-rpath $LD_LIBRARY_PATH $PREFIX/lib/python${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}/site-packages/sentencepiece-$PKG_VERSION-py${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}-linux-${ARCH}.egg/_sentencepiece.cpython-${CONDA_PY}m-${ARCH_SO_NAME}-linux-gnu.so
+patchelf --page-size ${PAGE_SIZE} --set-rpath $LD_LIBRARY_PATH $PREFIX/lib/python${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}/site-packages/sentencepiece-$PKG_VERSION-py${SYS_PYTHON_MAJOR}.${SYS_PYTHON_MINOR}-linux-${ARCH}.egg/_sentencepiece.cpython-${CONDA_PY}m-${ARCH_SO_NAME}-linux-gnu.so
 
 cd ../tensorflow
 python setup.py install

--- a/conda-recipes/sentencepiece-feedstock/recipe/meta.yaml
+++ b/conda-recipes/sentencepiece-feedstock/recipe/meta.yaml
@@ -1,14 +1,15 @@
-{% set version = "0.1.83" %}
+{% set version = "0.1.84" %}
 {% set name = "sentencepiece" %}
 
-# This is the recipe for tensorflow-datasets
 package:
    name: {{ name }}
    version: {{ version }}
 
 source:
   git_url: https://github.com/google/sentencepiece
-  git_rev: v0.1.83 
+  git_rev: v0.1.84
+  patches:
+    - 0001-Use-CXX11_ABI-to-build-TensorFlow.patch
 
 build:
   number: 0 
@@ -17,6 +18,7 @@ requirements:
   build:
     - cmake >=3.1
     - make
+    - {{ compiler('cxx') }}
   host:
     - python
     - setuptools


### PR DESCRIPTION
Added support for x86, removed the yum install gcc and
replaced it with Anaconda's c++ compiler.

Patched Sentencepiece to build using the CX11 ABI

Fixed build.sh to handle ppc64le and x86_64 so paths and file names

Fixed `ELF load command alignment not page-aligned` error on ppc64le:
Used `getconf PAGE_SIZE` to determine the PAGE_SIZE for the system
and pass that to patchelf.