### PR TITLE
Updated recipe with opencv version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,22 +24,10 @@ env:
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_noarch UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux-ppc64le
-      language: generic
-
-    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
-      os: linux-ppc64le
-      language: generic
-
-    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
-      os: linux-64
-      language: generic
-
-    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
-      os: linux-64
       language: generic
 
 script:
-  -  cd conda-recipes/shap-feedstock
+  -  cd conda-recipes/gym-feedstock
   -  ./ci_support/run_docker_build.sh

--- a/conda-recipes/gym-feedstock/.ci_support/linux_noarch.yaml
+++ b/conda-recipes/gym-feedstock/.ci_support/linux_noarch.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '8'
 channel_sources:
-- powerai,defaults
+- https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/,powerai,defaults
 channel_targets:
 - powerai main
 docker_image:

--- a/conda-recipes/gym-feedstock/recipe/meta.yaml
+++ b/conda-recipes/gym-feedstock/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pyglet>=1.2.0,<=1.3.2
     - cloudpickle~=1.2.0
     - enum34~=1.1.6     #[py27] 
-    - py-opencv
+    - py-opencv >=3.4.7
 
 test:
   imports:


### PR DESCRIPTION
Tensor2tensor has many dependencies which depend on protobuf >=3.8.0. 
If we don't specify any version for opencv for gym, opencv being fetched is 3.4.1 from defaults channel which depends on protobuf >3.5, <3.6.0. And this causes dependency conflicts.
With opencv-python >= 3.4.7, opencv being fetched is from our public channel which is 3.4.7 and it depends on protobuf >=3.8.0.