### PR TITLE
Python 2.7 support for h5py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ env:
 
 matrix:
   include:
+    - env: CONFIG=linux_ppc64le_python2.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux-ppc64le
+      arch: ppc64le
+      language: generic
+
     - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux-ppc64le
       arch: ppc64le

--- a/conda-recipes/h5py-feedstock/.ci_support/linux_ppc64le_python2.7.yaml
+++ b/conda-recipes/h5py-feedstock/.ci_support/linux_ppc64le_python2.7.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/conda-recipes/h5py-feedstock/recipe/meta.yaml
+++ b/conda-recipes/h5py-feedstock/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - python
     - hdf5
     - six
+    - unittest2  # [py27]
 
 test:
   imports:


### PR DESCRIPTION
PowerAI 1.5.4 has a neeed for h5py 2.9.0, so a python 2.7 build is needed