### PR TITLE
Add gpucheck to see if base cpuset.mems is ready

### DIFF
--- a/support/cpuset_fix/cpuset_check.sh
+++ b/support/cpuset_fix/cpuset_check.sh
@@ -121,7 +121,7 @@ function calculateCpuset {
     getV100Count
     cpuset="0,8"
     if [ $v100 -eq "0" ] ; then
-        echo "You have no GPUs"
+        echo "INFO: There are no V100 GPUs detected."
         gpumemset=
     elif [ $v100 -eq "1" ] ; then
         gpumemset=",255"
@@ -149,7 +149,7 @@ function isGpuMemReady {
     calculateCpuset
     cpuset_cur=$(cat $CPUSET_DIR/cpuset.mems)
     if [ "$cpuset_cur" == "$targetcpuset" ]; then
-        echo "SUCCESS: We have a match, GPU Memory Onlined"
+        echo "SUCCESS: Generated cpuset $cpuset_cur matches target cpuset.mems."
         return 0
     else
         echo "INFO: GPU Memory doesn't match cpuset.mems.  Memory still onlining"


### PR DESCRIPTION
Add a check to the script to tell if the system is initially at a valid
memory state.  i.e. all gpu memory is onlined and added to cgroups.  The
check uses lspci to gather the number of V100 gpus in the box, and
calculate the correct cpuset.mems.  After the calculation a comparison
is made between the calculated cpuset.mems and the system created one.
If they match, we can safely assume all gpu nodes are onlined.  If not a
message is printed out and a Return Code of 1 is generated.