### PR TITLE
Removed conda-forge from channel sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ matrix:
       language: generic
 
 script:
-  -  cd conda-recipes/aif360-feedstock
+  -  cd conda-recipes/tensorflow-datasets-feedstock
+  -  "travis_wait 60 sleep 3600 &"
   -  ./ci_support/run_docker_build.sh

--- a/conda-recipes/tensorflow-datasets-feedstock/.ci_support/linux_noarch.yaml
+++ b/conda-recipes/tensorflow-datasets-feedstock/.ci_support/linux_noarch.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '8'
 channel_sources:
-- conda-forge,defaults,powerai
+- defaults,powerai
 channel_targets:
 - powerai main
 docker_image:

--- a/conda-recipes/tensorflow-datasets-feedstock/ci_support/build_steps.sh
+++ b/conda-recipes/tensorflow-datasets-feedstock/ci_support/build_steps.sh
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
+# (C) Copyright IBM Corp. 2018, 2019. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Master branch build after my last PR merge for tensorflow datasets has been failing at conda install step. And I noticed dependencies are being installed from conda-forge instead of default channel. Not sure if this is the cause. But this anyway needed a correction.