### PR TITLE
pycuda conda recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,6 @@ matrix:
       os: linux-64
       arch: x86_64
 script:
-  -  cd conda-recipes/fbprophet-feedstock
+  -  cd conda-recipes/pycuda-feedstock
   -  "travis_wait 60 sleep 3600 &"
   -  ./ci_support/run_docker_build.sh 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ env:
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-pytorch-ubuntu18.04-py36-ppc64le
       language: generic
       os: linux-ppc64le
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-pytorch-ubuntu18.04-py37-ppc64le
       language: generic
       os: linux-ppc64le
       arch: ppc64le

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- main,conda-forge
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '8'
 channel_sources:
-- main,conda-forge
+- https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda,defaults,conda-forge
 channel_targets:
 - powerai main
 docker_image:

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '8'
 channel_sources:
-- main,conda-forge
+- https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda,defaults,conda-forge
 channel_targets:
 - powerai main
 docker_image:

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- main,conda-forge
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.6.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.6.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '7'
 channel_sources:
-- main,conda-forge
+- https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda,defaults,conda-forge
 channel_targets:
 - powerai main
 docker_image:

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.6.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.6.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- main,conda-forge
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.7.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.7.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '7'
 channel_sources:
-- main,conda-forge
+- https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda,defaults,conda-forge
 channel_targets:
 - powerai main
 docker_image:

--- a/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.7.yaml
+++ b/conda-recipes/pycuda-feedstock/.ci_support/linux_python3.7.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- main,conda-forge
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/conda-recipes/pycuda-feedstock/LICENSE
+++ b/conda-recipes/pycuda-feedstock/LICENSE
@@ -1,0 +1,42 @@
+PyCUDA is licensed to you under the MIT/X Consortium license:
+
+Copyright (c) 2009,10 Andreas KlÃ¶ckner and Contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+PyCUDA includes derivatives of parts of the `Thrust
+<https://github.com/thrust/thrust/>`_ computing package (in particular the scan
+implementation). These parts are licensed as follows:
+
+    Copyright 2008-2011 NVIDIA Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        <http://www.apache.org/licenses/LICENSE-2.0>
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/conda-recipes/pycuda-feedstock/README.rst
+++ b/conda-recipes/pycuda-feedstock/README.rst
@@ -1,0 +1,35 @@
+PyCUDA lets you access `Nvidia <http://nvidia.com>`_'s `CUDA
+<http://nvidia.com/cuda/>`_ parallel computation API from Python.
+Several wrappers of the CUDA API already exist-so what's so special
+about PyCUDA?
+
+.. image:: https://badge.fury.io/py/pycuda.png
+       :target: http://pypi.python.org/pypi/pycuda
+
+* Object cleanup tied to lifetime of objects. This idiom, often
+  called
+  `RAII <http://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization>`_
+  in C++, makes it much easier to write correct, leak- and
+  crash-free code. PyCUDA knows about dependencies, too, so (for
+  example) it won't detach from a context before all memory
+  allocated in it is also freed.
+
+* Convenience. Abstractions like pycuda.driver.SourceModule and
+  pycuda.gpuarray.GPUArray make CUDA programming even more
+  convenient than with Nvidia's C-based runtime.
+
+* Completeness. PyCUDA puts the full power of CUDA's driver API at
+  your disposal, if you wish. It also includes code for
+  interoperability with OpenGL.
+
+* Automatic Error Checking. All CUDA errors are automatically
+  translated into Python exceptions.
+
+* Speed. PyCUDA's base layer is written in C++, so all the niceties
+  above are virtually free.
+
+* Helpful `Documentation <http://documen.tician.de/pycuda>`_ and a
+  `Wiki <http://wiki.tiker.net/PyCuda>`_.
+
+Relatedly, like-minded computing goodness for `OpenCL <http://khronos.org>`_
+is provided by PyCUDA's sister project `PyOpenCL <http://pypi.python.org/pypi/pyopencl>`_.

--- a/conda-recipes/pycuda-feedstock/ci_support/build_steps.sh
+++ b/conda-recipes/pycuda-feedstock/ci_support/build_steps.sh
@@ -20,6 +20,9 @@ export FEEDSTOCK_ROOT=/home/conda/feedstock_root
 export RECIPE_ROOT=/home/conda/recipe_root
 export CI_SUPPORT=/home/conda/feedstock_root/.ci_support
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export PATH=/opt/anaconda/bin:$PATH
+
+conda install --yes git
 
 cat >~/.condarc <<CONDARC
 
@@ -28,9 +31,6 @@ conda-build:
 
 CONDARC
 
-conda config --prepend channels https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
-export IBM_POWERAI_LICENSE_ACCEPT=yes
-
 conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 
 # set up the condarc
@@ -38,6 +38,10 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+conda config --prepend channels https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
+conda config --set channel_priority strict
+export IBM_POWERAI_LICENSE_ACCEPT=yes
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" 

--- a/conda-recipes/pycuda-feedstock/ci_support/build_steps.sh
+++ b/conda-recipes/pycuda-feedstock/ci_support/build_steps.sh
@@ -1,0 +1,49 @@
+# (C) Copyright IBM Corp. 2018, 2019. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+export PYTHONUNBUFFERED=1
+export FEEDSTOCK_ROOT=/home/conda/feedstock_root
+export RECIPE_ROOT=/home/conda/recipe_root
+export CI_SUPPORT=/home/conda/feedstock_root/.ci_support
+export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+
+cat >~/.condarc <<CONDARC
+
+conda-build:
+ root-dir: /home/conda/feedstock_root/build_artifacts
+
+CONDARC
+
+conda config --prepend channels https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
+export IBM_POWERAI_LICENSE_ACCEPT=yes
+
+conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+
+# set up the condarc
+setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+# make the build number clobber
+make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" 
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+fi
+
+touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/conda-recipes/pycuda-feedstock/ci_support/run_docker_build.sh
+++ b/conda-recipes/pycuda-feedstock/ci_support/run_docker_build.sh
@@ -1,0 +1,67 @@
+# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
+PROVIDER_DIR="$(basename $THISDIR)"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+RECIPE_ROOT=$FEEDSTOCK_ROOT/recipe
+
+docker info
+
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+export HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
+ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
+mkdir -p "$ARTIFACTS"
+DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
+rm -f "$DONE_CANARY"
+
+# Enable running in interactive mode ONLY if attached to a tty,
+# so "-t" is made conditional
+test -t 1 && USE_TTY="-t"
+DOCKER_RUN_ARGS=" -i ${USE_TTY} "
+
+if [ -z "${DOCKER_IMAGE}" ]; then
+  echo "WARNING: DOCKER_IMAGE variable not set. Falling back to condaforge/linux-anvil-ppc64le"
+  DOCKER_IMAGE="condaforge/linux-anvil-ppc64le"
+fi
+
+docker run ${DOCKER_RUN_ARGS} \
+                        -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+                        -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+                        -e CONFIG \
+                        -e BINSTAR_TOKEN \
+                        -e HOST_USER_ID \
+                        -e UPLOAD_PACKAGES \
+                        -e CI \
+                        -a stdin -a stdout -a stderr \
+                        $DOCKER_IMAGE \
+                        bash \
+                        /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+
+test -f "$DONE_CANARY"

--- a/conda-recipes/pycuda-feedstock/ci_support/run_docker_build.sh
+++ b/conda-recipes/pycuda-feedstock/ci_support/run_docker_build.sh
@@ -55,7 +55,7 @@ docker run ${DOCKER_RUN_ARGS} \
                         -e HOST_USER_ID \
                         -e UPLOAD_PACKAGES \
                         -e CI \
-                        -a stdin -a stdout -a stderr \
+                        -a stdin -a stdout -a stderr --privileged=true -u root \
                         $DOCKER_IMAGE \
                         bash \
                         /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh

--- a/conda-recipes/pycuda-feedstock/recipe/meta.yaml
+++ b/conda-recipes/pycuda-feedstock/recipe/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "pycuda" %}
+{% set version = "2019.1.2" %}
+{% set build = 0 %}
+{% set hash = "ada56ce98a41f9f95fe18809f38afbae473a5c62d346cfa126a2d5477f24cc8a" %}
+{% set hash_type = "sha256" %}
+{% set bundle = "tar.gz" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: 
+    - python configure.py --cuda-root=$PREFIX/cuda
+    - python setup.py install --single-version-externally-managed --record record.txt
+ 
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - numpy>=1.6
+    - cudatoolkit>=10.1
+    - cudatoolkit-dev>=10.1
+  run:
+    - python
+    - numpy>=1.6
+    - pytools>=2011.2
+    - decorator>=3.2.0
+    - appdirs>=1.4.0
+    - mako
+    - cudatoolkit>=10.1
+    - cudatoolkit-dev>10.1
+
+test:
+  imports:
+    - pycuda
+
+about:
+  home: http://mathema.tician.de/software/pycuda/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'PyCUDA lets you access Nvidia‘s CUDA parallel computation API from Python'
+  description: |
+      Install command:
+      conda install -c https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/ -c defaults -c powerai -c conda-forge pycuda
+  doc_url: https://documen.tician.de/pycuda/
+  description: |
+  dev_url: https://git.tiker.net/pycuda.git


### PR DESCRIPTION
pycuda requires nvcc at runtime, so it has a dependency on cudatoolkit-dev

Tested that pycuda build against CUDA 10.2, works against CUDA 10.1

Requires conda-forge for the pytools package