### PR TITLE
add 'rust-nightly' feedstock based on conda-forge/rust-feedstock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,26 +24,16 @@ env:
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-pytorch-ubuntu18.04-py36-ppc64le
+    - env: CONFIG=linux_ppc64le UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       language: generic
       os: linux-ppc64le
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-pytorch-ubuntu18.04-py37-ppc64le
-      language: generic
-      os: linux-ppc64le
-      arch: ppc64le
-
-    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
-      language: generic
-      os: linux-64
-      arch: x86_64
-
-    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
+    - env: CONFIG=linux_64 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
       language: generic
       os: linux-64
       arch: x86_64
 script:
-  -  cd conda-recipes/pycuda-feedstock
+  -  cd conda-recipes/rust-nightly-feedstock
   -  "travis_wait 60 sleep 3600 &"
   -  ./ci_support/run_docker_build.sh 

--- a/conda-recipes/rust-nightly-feedstock/.ci_support/linux_64.yaml
+++ b/conda-recipes/rust-nightly-feedstock/.ci_support/linux_64.yaml
@@ -1,0 +1,10 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-comp7

--- a/conda-recipes/rust-nightly-feedstock/.ci_support/linux_64.yaml
+++ b/conda-recipes/rust-nightly-feedstock/.ci_support/linux_64.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '7'
 channel_sources:
 - defaults
 channel_targets:

--- a/conda-recipes/rust-nightly-feedstock/.ci_support/linux_ppc64le.yaml
+++ b/conda-recipes/rust-nightly-feedstock/.ci_support/linux_ppc64le.yaml
@@ -1,0 +1,10 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-ppc64le

--- a/conda-recipes/rust-nightly-feedstock/LICENSE.txt
+++ b/conda-recipes/rust-nightly-feedstock/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2019, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/conda-recipes/rust-nightly-feedstock/README.md
+++ b/conda-recipes/rust-nightly-feedstock/README.md
@@ -1,0 +1,186 @@
+About rust
+==========
+
+Home: https://www.rust-lang.org
+
+Package license: MIT
+
+Feedstock license: BSD 3-Clause
+
+Summary: Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.
+This package provides the compiler (rustc) and the documentation utilities rustdoc.
+
+
+
+
+Current build status
+====================
+
+
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/rust-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/rust-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr><tr>
+    <td>Drone</td>
+    <td>
+      <a href="https://cloud.drone.io/conda-forge/rust-feedstock">
+        <img alt="linux" src="https://img.shields.io/drone/build/conda-forge/master.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
+    
+  <tr>
+    <td>Azure</td>
+    <td>
+      <details>
+        <summary>
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4321&branchName=master">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=master">
+          </a>
+        </summary>
+        <table>
+          <thead><tr><th>Variant</th><th>Status</th></tr></thead>
+          <tbody><tr>
+              <td>linux</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4321&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=master&jobName=linux&configuration=linux_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4321&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4321&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4321&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=master&jobName=osx&configuration=osx_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4321&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=master&jobName=win&configuration=win_" alt="variant">
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
+    </td>
+  </tr>
+</table>
+
+Current release info
+====================
+
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rust-green.svg)](https://anaconda.org/conda-forge/rust) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rust.svg)](https://anaconda.org/conda-forge/rust) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rust.svg)](https://anaconda.org/conda-forge/rust) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rust.svg)](https://anaconda.org/conda-forge/rust) |
+
+Installing rust
+===============
+
+Installing `rust` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+
+```
+conda config --add channels conda-forge
+```
+
+Once the `conda-forge` channel has been enabled, `rust` can be installed with:
+
+```
+conda install rust
+```
+
+It is possible to list all of the versions of `rust` available on your platform with:
+
+```
+conda search rust --channel conda-forge
+```
+
+
+About conda-forge
+=================
+
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+
+conda-forge is a community-led conda channel of installable packages.
+In order to provide high-quality builds, the process has been automated into the
+conda-forge GitHub organization. The conda-forge organization contains one repository
+for each of the installable packages. Such a repository is known as a *feedstock*.
+
+A feedstock is made up of a conda recipe (the instructions on what and how to build
+the package) and the necessary configurations for automatic building using freely
+available continuous integration services. Thanks to the awesome service provided by
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
+packages to the [conda-forge](https://anaconda.org/conda-forge)
+[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+
+To manage the continuous integration and simplify feedstock maintenance
+[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
+Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
+this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
+
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+
+Terminology
+===========
+
+**feedstock** - the conda recipe (raw material), supporting scripts and CI configuration.
+
+**conda-smithy** - the tool which helps orchestrate the feedstock.
+                   Its primary use is in the construction of the CI ``.yml`` files
+                   and simplify the management of *many* feedstocks.
+
+**conda-forge** - the place where the feedstock and smithy live and work to
+                  produce the finished article (built conda distributions)
+
+
+Updating rust-feedstock
+=======================
+
+If you would like to improve the rust recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/rust-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
+
+In order to produce a uniquely identifiable distribution:
+ * If the version of a package **is not** being increased, please add or increase
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+ * If the version of a package **is** being increased, please remember to return
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   back to 0.
+
+Feedstock Maintainers
+=====================
+
+* [@abhi18av](https://github.com/abhi18av/)
+* [@dlaehnemann](https://github.com/dlaehnemann/)
+* [@johanneskoester](https://github.com/johanneskoester/)
+* [@pkgw](https://github.com/pkgw/)
+

--- a/conda-recipes/rust-nightly-feedstock/ci_support/build_steps.sh
+++ b/conda-recipes/rust-nightly-feedstock/ci_support/build_steps.sh
@@ -1,0 +1,46 @@
+# (C) Copyright IBM Corp. 2018, 2019. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+export PYTHONUNBUFFERED=1
+export FEEDSTOCK_ROOT=/home/conda/feedstock_root
+export RECIPE_ROOT=/home/conda/recipe_root
+export CI_SUPPORT=/home/conda/feedstock_root/.ci_support
+export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+
+cat >~/.condarc <<CONDARC
+
+conda-build:
+ root-dir: /home/conda/feedstock_root/build_artifacts
+
+CONDARC
+
+conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+
+# set up the condarc
+setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+# make the build number clobber
+make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+fi
+
+touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/conda-recipes/rust-nightly-feedstock/ci_support/run_docker_build.sh
+++ b/conda-recipes/rust-nightly-feedstock/ci_support/run_docker_build.sh
@@ -1,0 +1,59 @@
+# (C) Copyright IBM Corp. 2018, 2019. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
+PROVIDER_DIR="$(basename $THISDIR)"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+RECIPE_ROOT=$FEEDSTOCK_ROOT/recipe
+
+docker info
+
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+export HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
+ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
+mkdir -p "$ARTIFACTS"
+DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
+rm -f "$DONE_CANARY"
+# Enable running in interactive mode attached to a tty
+DOCKER_RUN_ARGS=" -it "
+
+docker run ${DOCKER_RUN_ARGS} \
+                        -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+                        -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+                        -e CONFIG \
+                        -e BINSTAR_TOKEN \
+                        -e HOST_USER_ID \
+                        -e UPLOAD_PACKAGES \
+                        -e CI \
+                        -a stdin -a stdout -a stderr \
+                        condaforge/linux-anvil-ppc64le \
+                        bash \
+                        /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+
+test -f "$DONE_CANARY"

--- a/conda-recipes/rust-nightly-feedstock/recipe/build.sh
+++ b/conda-recipes/rust-nightly-feedstock/recipe/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+./install.sh --prefix=$PREFIX
+
+# Fun times -- by default, Rust/Cargo tries to link executables on Linux by
+# invoking `cc`. An executable of this name is not necessarily available. By
+# setting a magic environment variable, we can override this default.
+
+if [ "$c_compiler" = gcc ] ; then
+    case "$BUILD" in
+        x86_64-*) rust_env_arch=X86_64_UNKNOWN_LINUX_GNU ;;
+        aarch64-*) rust_env_arch=AARCH64_UNKNOWN_LINUX_GNU ;;
+        powerpc64le-*) rust_env_arch=POWERPC64LE_UNKNOWN_LINUX_GNU ;;
+        *) echo "unknown BUILD $BUILD" ; exit 1 ;;
+    esac
+
+    mkdir -p $PREFIX/etc/conda/activate.d $PREFIX/etc/conda/deactivate.d
+
+    cat <<EOF >$PREFIX/etc/conda/activate.d/rust.sh
+export CARGO_TARGET_${rust_env_arch}_LINKER=\$CC
+EOF
+
+    cat <<EOF >$PREFIX/etc/conda/deactivate.d/rust.sh
+unset CARGO_TARGET_${rust_env_arch}_LINKER
+EOF
+fi

--- a/conda-recipes/rust-nightly-feedstock/recipe/forge_test.sh
+++ b/conda-recipes/rust-nightly-feedstock/recipe/forge_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e -x
+
+## TODO: remove the following `unset` lines, once the following issue in `conda-build` is resolved:
+##       <https://github.com/conda/conda-build/issues/2255>
+
+unset REQUESTS_CA_BUNDLE
+unset SSL_CERT_FILE
+
+rustc --help
+rustdoc --help
+cargo --help
+cargo install --force xsv

--- a/conda-recipes/rust-nightly-feedstock/recipe/meta.yaml
+++ b/conda-recipes/rust-nightly-feedstock/recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "1.43.0" %}
+
+package:
+  name: rust-nightly
+  version: {{ version }}
+
+source:
+  url: https://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
+  url: https://static.rust-lang.org/dist/rust-nightly-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
+  url: https://static.rust-lang.org/dist/rust-nightly-powerpc64le-unknown-linux-gnu.tar.gz  # [ppc64le]
+  url: https://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz       # [osx]
+  url: https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-msvc.tar.gz    # [win64]
+
+build:
+  number: 0
+  # the distributed binaries are already relocatable
+  binary_relocation: False
+
+requirements:
+  build:
+    - posix  # [win]
+  run:
+    - {{ compiler('c') }}  # [linux] -- rustc needs a toolchain to link executables on Linux
+
+test:
+  files:
+    - forge_test.sh
+  commands:
+    - time bash ./forge_test.sh  # [not win]
+    - bash forge_test.sh  # [win]
+    - rustc -V | grep -q {{ version }}-nightly # [(linux and x86_64) or ppc64le]
+
+about:
+  home: https://www.rust-lang.org
+  license: MIT
+  license_file:
+    - LICENSE-APACHE
+    - LICENSE-MIT
+  summary: |
+    Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.
+    This package provides the compiler (rustc) and the documentation utilities rustdoc.
+  dev_url: https://doc.rust-lang.org/std/
+  doc_url: https://www.rust-lang.org/en-US/documentation.html
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - abhi18av
+    - pkgw
+    - dlaehnemann


### PR DESCRIPTION
Add a feedstock recipe for building a 'rust-nightly' package from the
upstream binary distribution tarballs. This recipe is based on:

https://github.com/conda-forge/rust-feedstock

And note some discussion there about building nightlies:

https://github.com/conda-forge/rust-feedstock/issues/31

One complication with the nightlies is that the source URLs for rust
nightly builds are only versioned with the word 'nightly'. They don't
contain an indication of the actual rust version that's included,
and presumably they'll change from time to time.

That leads to 2 issues:

1) The SHA hashes in the recipe may often be invalidated.

"Fix" this by removing the hashes from meta.yaml.

2) The 'rust-nightly' package version is hard-coded in meta.yaml and
so may fall out of sync with the internal rust version in the
download. In this case the build would succeed, but the package
version would be misleading.

Fix this by including a build test to confirm that the rust version
in the built package actually matches the package version. That
will at least force a build break, rather than allowing creation
of a mis-versioned package.