### PR TITLE
add feedstock for huggingface/transformers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,6 @@ matrix:
       os: linux-64
       arch: x86_64
 script:
-  -  cd conda-recipes/tokenizers-feedstock
+  -  cd conda-recipes/transformers-feedstock
   -  "travis_wait 60 sleep 3600 &"
   -  ./ci_support/run_docker_build.sh 

--- a/conda-recipes/transformers-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
+++ b/conda-recipes/transformers-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- powerai,conda-forge,defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/conda-recipes/transformers-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
+++ b/conda-recipes/transformers-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- powerai,conda-forge,defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/conda-recipes/transformers-feedstock/.ci_support/linux_python3.6.yaml
+++ b/conda-recipes/transformers-feedstock/.ci_support/linux_python3.6.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- powerai,conda-forge,defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/conda-recipes/transformers-feedstock/.ci_support/linux_python3.7.yaml
+++ b/conda-recipes/transformers-feedstock/.ci_support/linux_python3.7.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- powerai,conda-forge,defaults
+channel_targets:
+- powerai main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/conda-recipes/transformers-feedstock/LICENSE.txt
+++ b/conda-recipes/transformers-feedstock/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2019, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/conda-recipes/transformers-feedstock/README.md
+++ b/conda-recipes/transformers-feedstock/README.md
@@ -1,0 +1,120 @@
+About transformers
+==================
+
+Home: https://github.com/huggingface/transformers
+
+Package license: Apache-2.0
+
+Feedstock license: BSD 3-Clause
+
+Summary: State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch
+
+
+
+Current build status
+====================
+
+
+<table><tr><td>All platforms:</td>
+    <td>
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8105&branchName=master">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/transformers-feedstock?branchName=master">
+      </a>
+    </td>
+  </tr>
+</table>
+
+Current release info
+====================
+
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-transformers-green.svg)](https://anaconda.org/conda-forge/transformers) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/transformers.svg)](https://anaconda.org/conda-forge/transformers) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/transformers.svg)](https://anaconda.org/conda-forge/transformers) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/transformers.svg)](https://anaconda.org/conda-forge/transformers) |
+
+Installing transformers
+=======================
+
+Installing `transformers` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+
+```
+conda config --add channels conda-forge
+```
+
+Once the `conda-forge` channel has been enabled, `transformers` can be installed with:
+
+```
+conda install transformers
+```
+
+It is possible to list all of the versions of `transformers` available on your platform with:
+
+```
+conda search transformers --channel conda-forge
+```
+
+
+About conda-forge
+=================
+
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+
+conda-forge is a community-led conda channel of installable packages.
+In order to provide high-quality builds, the process has been automated into the
+conda-forge GitHub organization. The conda-forge organization contains one repository
+for each of the installable packages. Such a repository is known as a *feedstock*.
+
+A feedstock is made up of a conda recipe (the instructions on what and how to build
+the package) and the necessary configurations for automatic building using freely
+available continuous integration services. Thanks to the awesome service provided by
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
+packages to the [conda-forge](https://anaconda.org/conda-forge)
+[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+
+To manage the continuous integration and simplify feedstock maintenance
+[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
+Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
+this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
+
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+
+Terminology
+===========
+
+**feedstock** - the conda recipe (raw material), supporting scripts and CI configuration.
+
+**conda-smithy** - the tool which helps orchestrate the feedstock.
+                   Its primary use is in the construction of the CI ``.yml`` files
+                   and simplify the management of *many* feedstocks.
+
+**conda-forge** - the place where the feedstock and smithy live and work to
+                  produce the finished article (built conda distributions)
+
+
+Updating transformers-feedstock
+===============================
+
+If you would like to improve the transformers recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/transformers-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
+
+In order to produce a uniquely identifiable distribution:
+ * If the version of a package **is not** being increased, please add or increase
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+ * If the version of a package **is** being increased, please remember to return
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   back to 0.
+
+Feedstock Maintainers
+=====================
+
+* [@roccqqck](https://github.com/roccqqck/)
+

--- a/conda-recipes/transformers-feedstock/ci_support/build_steps.sh
+++ b/conda-recipes/transformers-feedstock/ci_support/build_steps.sh
@@ -38,7 +38,9 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda config --prepend channels https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
-conda config --set channel_priority strict
+# Run/test pre-reqs come from 4 different channels; strict priority breaks
+# ability to install them all. Do not use.
+#conda config --set channel_priority strict
 export IBM_POWERAI_LICENSE_ACCEPT=yes
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \

--- a/conda-recipes/transformers-feedstock/ci_support/build_steps.sh
+++ b/conda-recipes/transformers-feedstock/ci_support/build_steps.sh
@@ -1,0 +1,51 @@
+# (C) Copyright IBM Corp. 2018, 2019. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+export PYTHONUNBUFFERED=1
+export FEEDSTOCK_ROOT=/home/conda/feedstock_root
+export RECIPE_ROOT=/home/conda/recipe_root
+export CI_SUPPORT=/home/conda/feedstock_root/.ci_support
+export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export PATH=/opt/anaconda/bin:$PATH
+
+cat >~/.condarc <<CONDARC
+
+conda-build:
+ root-dir: /home/conda/feedstock_root/build_artifacts
+
+CONDARC
+
+conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+
+# set up the condarc
+setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+# make the build number clobber
+make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+conda config --prepend channels https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
+conda config --set channel_priority strict
+export IBM_POWERAI_LICENSE_ACCEPT=yes
+
+conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+fi
+
+touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/conda-recipes/transformers-feedstock/ci_support/run_docker_build.sh
+++ b/conda-recipes/transformers-feedstock/ci_support/run_docker_build.sh
@@ -1,0 +1,67 @@
+# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
+PROVIDER_DIR="$(basename $THISDIR)"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+RECIPE_ROOT=$FEEDSTOCK_ROOT/recipe
+
+docker info
+
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+export HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
+ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
+mkdir -p "$ARTIFACTS"
+DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
+rm -f "$DONE_CANARY"
+
+# Enable running in interactive mode ONLY if attached to a tty,
+# so "-t" is made conditional
+test -t 1 && USE_TTY="-t"
+DOCKER_RUN_ARGS=" -i ${USE_TTY} "
+
+if [ -z "${DOCKER_IMAGE}" ]; then
+  echo "WARNING: DOCKER_IMAGE variable not set. Falling back to condaforge/linux-anvil-ppc64le"
+  DOCKER_IMAGE="condaforge/linux-anvil-ppc64le"
+fi
+
+docker run ${DOCKER_RUN_ARGS} \
+                        -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+                        -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+                        -e CONFIG \
+                        -e BINSTAR_TOKEN \
+                        -e HOST_USER_ID \
+                        -e UPLOAD_PACKAGES \
+                        -e CI \
+                        -a stdin -a stdout -a stderr --privileged=true -u root \
+                        $DOCKER_IMAGE \
+                        bash \
+                        /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+
+test -f "$DONE_CANARY"

--- a/conda-recipes/transformers-feedstock/recipe/meta.yaml
+++ b/conda-recipes/transformers-feedstock/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - transformers.data.metrics
     - transformers.data.processors
   commands:
-    - transformers-cli --help
+    - python $CONDA_PREFIX/bin/transformers-cli --help
   requires:
     - pytest
 

--- a/conda-recipes/transformers-feedstock/recipe/meta.yaml
+++ b/conda-recipes/transformers-feedstock/recipe/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "transformers" %} 
+{% set version = "2.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c4b775ebffce65e1d8f2e5db74c5efdc4426ebecdaee1516c90573aafa1ceaf4
+
+build:
+  noarch: python
+  number: 0
+  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - boto3
+    - filelock
+    - numpy
+    - python
+    - regex
+    - requests
+    - sacremoses
+    - sentencepiece
+    - tokenizers
+    - tqdm
+
+test:
+  imports:
+    - transformers
+    - transformers.data
+    - transformers.data.metrics
+    - transformers.data.processors
+  commands:
+    - transformers-cli --help
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/huggingface/transformers
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch
+  doc_url: https://huggingface.co/transformers/
+
+extra:
+  recipe-maintainers:
+    - hartb


### PR DESCRIPTION
Add feedstock for huggingface/transformers. This recipe is based on
the upstream conda-forge recipe:

https://github.com/conda-forge/transformers-feedstock

And includes changes based on a automatic version-update PR:

https://github.com/conda-forge/transformers-feedstock/pull/9

As well further changes to get the build working at all, and in the
powerai channel context.