### PR TITLE
Change LightGBM to be Anaconda based vs forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,24 +29,25 @@ branches:
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py36
+    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       language: generic
 
-    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py37
+    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       language: generic
 
-    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py36
+    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
       os: linux
       arch: amd64
       language: generic
 
-    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py37
+    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
       os: linux
       arch: amd64
+      language: generic
 
 script:
   -  "travis_wait 60 sleep 3600 &"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,22 +29,22 @@ branches:
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py36
       os: linux
       arch: ppc64le
       language: generic
 
-    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py37
       os: linux
       arch: ppc64le
       language: generic
 
-    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
+    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py36
       os: linux
       arch: amd64
       language: generic
 
-    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=condaforge/linux-anvil-comp7
+    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py37
       os: linux
       arch: amd64
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,26 +29,26 @@ branches:
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-tensorflow-ubuntu18.04-py36
+    - env: CONFIG=linux_ppc64le_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py36
       os: linux
       arch: ppc64le
       language: generic
 
-    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-tensorflow-ubuntu18.04-py37
+    - env: CONFIG=linux_ppc64le_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py37
       os: linux
       arch: ppc64le
       language: generic
 
-    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-tensorflow-ubuntu18.04-py36
+    - env: CONFIG=linux_python3.6 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py36
       os: linux
       arch: amd64
       language: generic
 
-    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-tensorflow-ubuntu18.04-py37
+    - env: CONFIG=linux_python3.7 UPLOAD_PACKAGES=True DOCKER_IMAGE=ibmcom/powerai:1.7.0-base-ubuntu18.04-py37
       os: linux
       arch: amd64
 
 script:
-  -  cd conda-recipes/sentencepiece-feedstock
   -  "travis_wait 60 sleep 3600 &"
-  -  ./ci_support/run_docker_build.sh
+  -  ./conda-recipes/build_scripts/run_docker_build.sh lightgbm-feedstock
+

--- a/conda-recipes/build_scripts/build_steps.sh
+++ b/conda-recipes/build_scripts/build_steps.sh
@@ -32,7 +32,7 @@ CONDARC
 conda config --prepend channels https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
 export IBM_POWERAI_LICENSE_ACCEPT=yes
 
-conda install --yes --quiet conda-forge-ci-setup=2 conda-build=3.16 -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=2 conda-build=3.19.2 -c conda-forge
 
 # patchelf from conda-forge (0.10) causes errors. Use 0.9 from defaults
 conda install -y patchelf=0.9

--- a/conda-recipes/lightgbm-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
+++ b/conda-recipes/lightgbm-feedstock/.ci_support/linux_ppc64le_python3.6.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '8'
 channel_sources:
-- powerai,conda-forge,defaults
+- powerai,defaults
 channel_targets:
 - powerai main
 cxx_compiler:

--- a/conda-recipes/lightgbm-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
+++ b/conda-recipes/lightgbm-feedstock/.ci_support/linux_ppc64le_python3.7.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '8'
 channel_sources:
-- powerai,conda-forge,defaults
+- powerai,defaults
 channel_targets:
 - powerai main
 cxx_compiler:

--- a/conda-recipes/lightgbm-feedstock/.ci_support/linux_python3.6.yaml
+++ b/conda-recipes/lightgbm-feedstock/.ci_support/linux_python3.6.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '7'
 channel_sources:
-- powerai,conda-forge,defaults
+- powerai,defaults
 channel_targets:
 - powerai main
 cxx_compiler:

--- a/conda-recipes/lightgbm-feedstock/.ci_support/linux_python3.7.yaml
+++ b/conda-recipes/lightgbm-feedstock/.ci_support/linux_python3.7.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '7'
 channel_sources:
-- powerai,conda-forge,defaults
+- powerai,defaults
 channel_targets:
 - powerai main
 cxx_compiler:

--- a/conda-recipes/lightgbm-feedstock/recipe/meta.yaml
+++ b/conda-recipes/lightgbm-feedstock/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   skip: True  # [win32]
 
@@ -26,8 +26,6 @@ requirements:
     - python
     - pip
     - setuptools
-    - llvm-openmp  # [osx]
-    - libgomp  # [linux]
   run:
     - python
     - numpy


### PR DESCRIPTION
Forge has a separate package for libgomp.
Anaconda includes it in libgcc-ng.

This should allow the lightgbm packages to install along side most of WML CE and Anaconda.