### PR TITLE
common build: add callout to feedstock pre-build script

### DIFF
--- a/conda-recipes/build_scripts/build_steps.sh
+++ b/conda-recipes/build_scripts/build_steps.sh
@@ -42,6 +42,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+# Execute feedstock pre-build steps if they exist
+FEEDSTOCK_HOOK_SCRIPT="${FEEDSTOCK_ROOT}/build_steps_hook.sh"
+if [ -f "${FEEDSTOCK_HOOK_SCRIPT}" ]
+then
+    echo "Executing ${FEEDSTOCK_HOOK_SCRIPT}..."
+    bash "${FEEDSTOCK_HOOK_SCRIPT}"
+fi
+
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 

--- a/conda-recipes/build_scripts/local_build.sh
+++ b/conda-recipes/build_scripts/local_build.sh
@@ -39,6 +39,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+# Execute feedstock pre-build steps if they exist
+FEEDSTOCK_HOOK_SCRIPT="${FEEDSTOCK_ROOT}/build_steps_hook.sh"
+if [ -f "${FEEDSTOCK_HOOK_SCRIPT}" ]
+then
+    echo "Executing ${FEEDSTOCK_HOOK_SCRIPT}..."
+    bash "${FEEDSTOCK_HOOK_SCRIPT}"
+fi
+
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 


### PR DESCRIPTION
Allow feedstocks to provide a script to be called just before
"conda build". This allows feedstocks to use the common build
scripts but further customize the build environment if needed.

The script must be named "build_steps_hook.sh" and must reside
in the feedstock's top-level directory (not the "recipe/"
directory, to avoid confusion with any scripts that "conda build"
will later run.)

The script is run with "bash ..." so should be a bash script,
but need not have file execute permissions..